### PR TITLE
v1.15.9 + PR 2092

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = ros-noetic-rospy
 	pkgdesc = ROS - rospy is a pure Python client library for ROS.
-	pkgver = 1.15.8
+	pkgver = 1.15.9
 	pkgrel = 1
 	url = https://wiki.ros.org/rospy
 	arch = i686
@@ -21,8 +21,10 @@ pkgbase = ros-noetic-rospy
 	depends = python-yaml
 	depends = python-rospkg
 	depends = python-numpy
-	source = ros-noetic-rospy-1.15.8.tar.gz::https://github.com/ros/ros_comm/archive/1.15.8.tar.gz
-	sha256sums = 7a72219b236aef5f0327c3ce6eba6008980a24a986a5b970b17125890887b494
+	source = ros-noetic-rospy-1.15.9.tar.gz::https://github.com/ros/ros_comm/archive/1.15.9.tar.gz
+	source = 2092.patch::https://github.com/ros/ros_comm/pull/2092.patch
+	sha256sums = ee68c16fe6e2f3bf8fef4cf35552a30160cb3b579dfe18d667c0ba05e69ef90d
+	sha256sums = ad42681c4249a89f4a0188f8202e73286c4090bbc919a470543af7e8f1b198f4
 
 pkgname = ros-noetic-rospy
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@ pkgdesc="ROS - rospy is a pure Python client library for ROS."
 url='https://wiki.ros.org/rospy'
 
 pkgname='ros-noetic-rospy'
-pkgver='1.15.8'
+pkgver='1.15.9'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
 pkgrel=1
 license=('BSD')
@@ -34,8 +34,15 @@ depends=(
 )
 
 _dir="ros_comm-${pkgver}/clients/rospy"
-source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/ros_comm/archive/${pkgver}.tar.gz")
-sha256sums=('7a72219b236aef5f0327c3ce6eba6008980a24a986a5b970b17125890887b494')
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/ros/ros_comm/archive/${pkgver}.tar.gz"
+    "2092.patch"::"https://github.com/ros/ros_comm/pull/2092.patch")
+sha256sums=('ee68c16fe6e2f3bf8fef4cf35552a30160cb3b579dfe18d667c0ba05e69ef90d'
+    'ad42681c4249a89f4a0188f8202e73286c4090bbc919a470543af7e8f1b198f4')
+
+prepare() {
+    cd "ros_comm-${pkgver}"
+    patch -p1 -i "${srcdir}/2092.patch"
+}
 
 build() {
     # Use ROS environment variables.


### PR DESCRIPTION
Hi,

This fixed some unit test for me, eg:
```python
Traceback (most recent call last):
  File "…/lib/controller_manager/spawner", line 212, in <module>
    if __name__ == '__main__': main()
  File "…/lib/controller_manager/spawner", line 210, in main
    rospy.spin()
  File "/opt/ros/noetic/lib/python3.9/site-packages/rospy/client.py", line 129, in spin
    rospy.rostime.wallsleep(0.5)
  File "/opt/ros/noetic/lib/python3.9/site-packages/rospy/rostime.py", line 277, in wallsleep
    time.sleep(duration)
  File "/opt/ros/noetic/lib/python3.9/site-packages/rospy/core.py", line 602, in _ros_signal
    signal_shutdown("signal-"+str(sig))
  File "/opt/ros/noetic/lib/python3.9/site-packages/rospy/core.py", line 594, in signal_shutdown
    if t.isAlive():
AttributeError: 'Thread' object has no attribute 'isAlive'
```

ref: https://github.com/ros/ros_comm/pull/2092